### PR TITLE
Update readme with working installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,15 @@ Browser should supports are ES Modules, Promise, Blob and window.URL functions.
 
 ## Usage
 
+```
+npm install dynamic-import-polyfill
+```
+
 async / await style
 
 ```js
 <script type="module">
-import { importModule } from "https://uupaa.github.io/dynamic-import-polyfill/importModule.js";
+import { importModule } from "dynamic-import-polyfill/importModule.js";
 
 (async() => {
   const Modules = {
@@ -43,7 +47,7 @@ or Promise style.
 
 ```js
 <script type="module">
-import { importModule } from "https://uupaa.github.io/dynamic-import-polyfill/importModule.js";
+import { importModule } from "dynamic-import-polyfill/importModule.js";
 
 importModule("./Lib1.js").then(Lib1 => {
   const lib1 = new Lib1();


### PR DESCRIPTION
The examples only works if the code is loaded from the same domain, so loading it remote does not work and give you an error like 
```
SyntaxError: export declarations may only appear at top level of a module
```

However installing it and making `polymer` cli rewrite it to load it from the same domain, in the same way the examples loads the module, then it works 👍 