### PR TITLE
Fix for async/await

### DIFF
--- a/importModule.js
+++ b/importModule.js
@@ -22,12 +22,12 @@ export function importModule(url) {
       reject(new Error(`Failed to import: ${url}`));
       destructor();
     };
-    script.onload = () => {
-      resolve(window[vector]);
+    window[vector] = (value) => {
+      resolve(value);
       destructor();
     };
     const absURL = toAbsoluteURL(url);
-    const loader = `import * as m from "${absURL}"; window.${vector} = m;`; // export Module
+    const loader = `import * as m from "${absURL}"; window.${vector}(m);`; // export Module
     const blob = new Blob([loader], { type: "text/javascript" });
     script.src = URL.createObjectURL(blob);
 


### PR DESCRIPTION
A small tweak to allow async/await syntax at the top-level of the module to work properly because the script.onload event is ran immediately after the script is loaded, but before the module exports are available.